### PR TITLE
adds flag to ignore ephemeral devices.

### DIFF
--- a/cmd/baton-tailscale/main.go
+++ b/cmd/baton-tailscale/main.go
@@ -55,6 +55,7 @@ func getConnector(ctx context.Context, tsc *cfg.Tailscale) (types.ConnectorServe
 		ctx,
 		tsc.ApiKey,
 		tsc.Tailnet,
+		tsc.IgnoreEphemeralDevices,
 	)
 	if err != nil {
 		l.Error("error creating connector", zap.Error(err))

--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -6,6 +6,7 @@ import "reflect"
 type Tailscale struct {
 	ApiKey string `mapstructure:"api-key"`
 	Tailnet string `mapstructure:"tailnet"`
+	IgnoreEphemeralDevices bool `mapstructure:"ignore-ephemeral-devices"`
 }
 
 func (c* Tailscale) findFieldByTag(tagValue string) (any, bool) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,10 +19,18 @@ var (
 		field.WithRequired(true),
 		field.WithIsSecret(true),
 	)
+
+	IgnoreEphemeralDevicesField = field.BoolField(
+		"ignore-ephemeral-devices",
+		field.WithDisplayName("Ignore Ephemeral Devices"),
+		field.WithDescription("Skip ingesting devices with isEphemeral=true attribute"),
+	)
+
 	// ConfigurationFields defines the external configuration required for the connector to run.
 	ConfigurationFields = []field.SchemaField{
 		ApiKeyField,
 		TailnetField,
+		IgnoreEphemeralDevicesField,
 	}
 
 	Configurations     = field.NewConfiguration(ConfigurationFields)

--- a/pkg/connector/client/models.go
+++ b/pkg/connector/client/models.go
@@ -55,6 +55,7 @@ type Device struct {
 	TailnetLockKey            string    `json:"tailnetLockKey,omitempty"`
 	UpdateAvailable           bool      `json:"updateAvailable,omitempty"`
 	User                      string    `json:"user,omitempty"`
+	IsEphemeral               bool      `json:"isEphemeral,omitempty"`
 }
 
 type UserInvitesAPIData []struct {

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -11,7 +11,8 @@ import (
 )
 
 type Connector struct {
-	client *client.Client
+	client                 *client.Client
+	ignoreEphemeralDevices bool
 }
 
 // ResourceSyncers returns a ResourceSyncer for each resource type that should be synced from the upstream service.
@@ -22,7 +23,7 @@ func (d *Connector) ResourceSyncers(ctx context.Context) []connectorbuilder.Reso
 		newSSHRuleBuilder(d.client),
 		newUserBuilder(d.client),
 		newRoleBuilder(d.client),
-		newDeviceBuilder(d.client),
+		newDeviceBuilder(d.client, d.ignoreEphemeralDevices),
 	}
 }
 
@@ -47,10 +48,13 @@ func (d *Connector) Validate(ctx context.Context) (annotations.Annotations, erro
 }
 
 // New returns a new instance of the connector.
-func New(ctx context.Context, apiKey string, tailnet string) (*Connector, error) {
+func New(ctx context.Context, apiKey string, tailnet string, ignoreEphemeralDevices bool) (*Connector, error) {
 	client, err := client.New(ctx, apiKey, tailnet)
 	if err != nil {
 		return nil, err
 	}
-	return &Connector{client: client}, nil
+	return &Connector{
+		client:                 client,
+		ignoreEphemeralDevices: ignoreEphemeralDevices,
+	}, nil
 }

--- a/pkg/connector/device.go
+++ b/pkg/connector/device.go
@@ -49,12 +49,12 @@ func (d *deviceBuilder) List(ctx context.Context, parentResourceID *v2.ResourceI
 
 	for _, device := range devices {
 		deviceCopy := device
-		
+
 		// Skip ephemeral devices if configured to ignore them
 		if d.ignoreEphemeralDevices && deviceCopy.IsEphemeral {
 			continue
 		}
-		
+
 		dr, err := deviceResource(ctx, &deviceCopy, parentResourceID)
 		if err != nil {
 			return nil, "", nil, err

--- a/pkg/connector/device.go
+++ b/pkg/connector/device.go
@@ -11,8 +11,9 @@ import (
 )
 
 type deviceBuilder struct {
-	resourceType *v2.ResourceType
-	client       *client.Client
+	resourceType           *v2.ResourceType
+	client                 *client.Client
+	ignoreEphemeralDevices bool
 }
 
 func (d *deviceBuilder) ResourceType(ctx context.Context) *v2.ResourceType {
@@ -48,6 +49,12 @@ func (d *deviceBuilder) List(ctx context.Context, parentResourceID *v2.ResourceI
 
 	for _, device := range devices {
 		deviceCopy := device
+		
+		// Skip ephemeral devices if configured to ignore them
+		if d.ignoreEphemeralDevices && deviceCopy.IsEphemeral {
+			continue
+		}
+		
 		dr, err := deviceResource(ctx, &deviceCopy, parentResourceID)
 		if err != nil {
 			return nil, "", nil, err
@@ -67,9 +74,10 @@ func (d *deviceBuilder) Grants(ctx context.Context, resource *v2.Resource, pToke
 	return nil, "", nil, nil
 }
 
-func newDeviceBuilder(client *client.Client) *deviceBuilder {
+func newDeviceBuilder(client *client.Client, ignoreEphemeralDevices bool) *deviceBuilder {
 	return &deviceBuilder{
-		resourceType: deviceResourceType,
-		client:       client,
+		resourceType:           deviceResourceType,
+		client:                 client,
+		ignoreEphemeralDevices: ignoreEphemeralDevices,
 	}
 }


### PR DESCRIPTION
#### Description
- [ ] New feature: add --ignore-ephemeral-devices flag which will ignore devices flagged as ephemeral.




#### Useful links:

- [https://github.com/ConductorOne/baton-sdk/wiki/Coding-Guidelines](Baton SDK coding guidelines)
- [https://github.com/ConductorOne/baton/blob/main/CONTRIBUTING.md](New contributor guide)
